### PR TITLE
Allow + character in backup names.

### DIFF
--- a/src/benji/utils.py
+++ b/src/benji/utils.py
@@ -176,7 +176,7 @@ class TokenBucket:
 class InputValidation:
 
     QUALIFIED_NAME_REGEXP = '(?!-)[-a-zA-Z0-9_.]{1,63}(?<!-)'
-    VALUE_REGEXP = '(?!-)[-a-zA-Z0-9_.:/@]+(?<!-)'
+    VALUE_REGEXP = '(?!-)[-a-zA-Z0-9_.:/@+]+(?<!-)'
     OPTIONAL_VALUE_REGEXP = '(' + VALUE_REGEXP + ')?'
     DNS1123_LABEL_REGEXP = '(?!-)[-a-z0-9]{1,63}(?<!-)'
     DNS1123_SUBDOMAIN_REGEXP = DNS1123_LABEL_REGEXP + '(\\.' + DNS1123_LABEL_REGEXP + ')*'


### PR DESCRIPTION
RBD also allows that in snapshot names,
and a common usecase would be to name snapshots
like b-2018-11-18T01:22:12+0100 which contains a '+'.