### PR TITLE
rbd: Set _snapshot_name to empty string.

### DIFF
--- a/src/benji/io/rbd.py
+++ b/src/benji/io/rbd.py
@@ -62,6 +62,7 @@ class IO(IOBase):
         if not re_match:
             raise UsageError('IO path {} is invalid . Need {}://<pool>/<imagename>.'.format(self._path, self.name))
         self._pool_name, self._image_name = re_match.groups()
+        self._snapshot_name = ''
 
         # try opening it and quit if that's not possible.
         try:


### PR DESCRIPTION
Something later in the code, probably the size check,
assumes it exists and is set, and fails with:
   ERROR: 'IO' object has no attribute '_snapshot_name'
whenever trying to restore a backup to RBD.