### PR TITLE
benji-k8s: add primitive support for Rook

### DIFF
--- a/images/benji-k8s/bin/benji-backup-pvc
+++ b/images/benji-k8s/bin/benji-backup-pvc
@@ -298,15 +298,28 @@ for pvc in pvcs:
         continue
 
     pv = core_v1_api.read_persistent_volume(pvc.spec.volume_name)
-    if not hasattr(pv.spec, 'rbd') or not hasattr(pv.spec.rbd, 'pool') or not hasattr(pv.spec.rbd, 'image'):
+
+    pool, image = None, None
+
+    if hasattr(pv.spec, 'rbd') and hasattr(pv.spec.rbd, 'pool') and hasattr(pv.spec.rbd, 'image'):
+        # Native Kubernetes RBD PV
+        pool, image = spec.rbd.pool, spec.rbd.image
+    elif hasattr(pv.spec, 'flex_volume') and hasattr(pv.spec.flex_volume, 'options') and hasattr(pv.spec.flex_volume, 'driver'):
+        # Rook Ceph PV
+        options = pv.spec.flex_volume.options
+        driver = pv.spec.flex_volume.driver
+        if driver.startswith('ceph.rook.io/') and options.get('pool') and options.get('image'):
+            pool, image = options['pool'], options['image']
+
+    if pool is None or image is None:
         continue
 
     version_name = f'{pvc.metadata.namespace}/{pvc.metadata.name}'
 
     version_labels = {
         'benji-backup.me/instance': settings.benji_instance,
-        'benji-backup.me/ceph-pool': pv.spec.rbd.pool,
-        'benji-backup.me/ceph-rbd-image': pv.spec.rbd.image,
+        'benji-backup.me/ceph-pool': pool,
+        'benji-backup.me/ceph-rbd-image': image,
         'benji-backup.me/k8s-pvc-namespace': pvc.metadata.namespace,
         'benji-backup.me/k8s-pvc-name': pvc.metadata.name,
         'benji-backup.me/k8s-pv': pv.metadata.name
@@ -314,8 +327,7 @@ for pvc in pvcs:
 
     context = {'pvc': pvc}
     ceph.backup(version_name=version_name,
-                pool=pv.spec.rbd.pool,
-                image=pv.spec.rbd.image,
+                pool=pool, image=image,
                 version_labels=version_labels,
                 context=context)
 


### PR DESCRIPTION
This change adds very basic support for backing up Rook-managed Ceph RBDs. It lets benji-k8s retrieve information about pools/images from kubernetes when they are backed by Rook PVs.

Out of scope of this change:
 - retrieving ceph keyring/config from Rook  (currently I use /usr/local/bin/toolbox.sh from the Rook toolbox as a  replacement)
 - automatically marking all Rook pools as RBD-based IOs in the benji config file
 - support in benji-restore-pvc (will come in a future PR)