### PR TITLE
Add elliptic curve encryption transform module

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -450,9 +450,9 @@ cannot be decrypted anymore.
 
 
 Transform Module ecc
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
-This module encrypts each data block using the ``aes_256_gcm``module
+This module encrypts each data block using the ``aes_256_gcm`` module
 (see above). Instead of specifying a symmetric master key, the encryption
 key is encrypted asymmetrically using elliptic curve cryptography.
 
@@ -473,15 +473,13 @@ For restore (decryption) this must include the private key.
 
 The ECC curve to use. Valid values are 'NIST P-256', 'NIST P-384' and 'NIST P-521'.
 
-Example python code to create a valid ECC key for **EccKey** (using ``PyCryptodome``):
+Example python code to create a valid ECC key for **EccKey** (using ``PyCryptodome``)::
 
-```
-from base64 import b64encode
-from Crypto.PublicKey import ECC
-key = ECC.generate(curve=EccCurve)
-public_key = b64encode(key.public_key().export_key(format='DER', compress=True)).decode('ascii'))
-private_key = b64encode(key.export_key(format='DER', compress=True).decode('ascii'))
-```
+    from base64 import b64encode
+    from Crypto.PublicKey import ECC
+    key = ECC.generate(curve=EccCurve)
+    public_key = b64encode(key.public_key().export_key(format='DER', compress=True)).decode('ascii'))
+    private_key = b64encode(key.export_key(format='DER', compress=True).decode('ascii'))
 
 
 Storage Modules

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -448,6 +448,42 @@ your own random salt and chose your own number of iterations. Don't change
 the salt and iteration count after writing encrypted data objects,  they
 cannot be decrypted anymore.
 
+
+Transform Module ecc
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module encrypts each data block using the ``aes_256_gcm``module
+(see above). Instead of specifying a symmetric master key, the encryption
+key is encrypted asymmetrically using elliptic curve cryptography.
+
+
+The ``ecc`` module supports the following configuration options:
+
+* name: **EccKey**
+* type: BASE64-encoded DER representation of a ECC key (public or private)
+* default: none
+
+Specify the encryption keyfile to encrypt a block's symmetric key.
+For backup (encryption-only) this should be the public key only.
+For restore (decryption) this must include the private key.
+
+* name: **EccCurve**
+* type: string
+* default: ``NIST P-384``
+
+The ECC curve to use. Valid values are 'NIST P-256', 'NIST P-384' and 'NIST P-521'.
+
+Example python code to create a valid ECC key for **EccKey** (using ``PyCryptodome``):
+
+```
+from base64 import b64encode
+from Crypto.PublicKey import ECC
+key = ECC.generate(curve=EccCurve)
+public_key = b64encode(key.public_key().export_key(format='DER', compress=True)).decode('ascii'))
+private_key = b64encode(key.export_key(format='DER', compress=True).decode('ascii'))
+```
+
+
 Storage Modules
 ---------------
 

--- a/src/benji/tests/test_transform_ecc.py
+++ b/src/benji/tests/test_transform_ecc.py
@@ -1,3 +1,4 @@
+import base64
 from unittest import TestCase
 
 from Crypto.PublicKey import ECC
@@ -11,20 +12,17 @@ class TestEccTransform(TestCase):
     @staticmethod
     def _get_transform_args(key):
         conf = ConfigDict()
-        conf['EccKey'] = Transform._pack_envelope_key(key)
+        conf['EccKey'] = base64.b64encode(Transform._pack_envelope_key(key)).decode('ascii')
         conf['EccCurve'] = key.curve
         return Transform(name='EccTest', config=None, module_configuration=conf)
-
 
     @classmethod
     def _get_transform(cls):
         curve = 'NIST P-384'
         return cls._get_transform_args(ECC.generate(curve=curve))
-        
-    
+
     def setUp(self):
         self.ecc_transform = self._get_transform()
-
 
     def test_decryption(self):
         data = b'THIS IS A TEST'
@@ -35,7 +33,6 @@ class TestEccTransform(TestCase):
         dec_data = self.ecc_transform.decapsulate(data=enc_data, materials=materials)
         assert dec_data == data
 
-
     def test_encryption_random(self):
         ecc_transform_ref = self._get_transform()
 
@@ -45,17 +42,16 @@ class TestEccTransform(TestCase):
         enc_data_ref, materials_ref = ecc_transform_ref.encapsulate(data=data)
 
         assert enc_data != enc_data_ref
-        assert materials['ecc_envelope_key'] != materials_ref['ecc_envelope_key']
-
+        assert materials['envelope_key'] != materials_ref['envelope_key']
 
     def test_envelope_key(self):
         data = b'THIS IS A TEST'
         
         enc_data, materials = self.ecc_transform.encapsulate(data=data)
 
-        envelope_key = self.ecc_transform._unpack_envelope_key(materials['ecc_envelope_key'])
+        envelope_key = self.ecc_transform._unpack_envelope_key(
+            base64.b64decode(materials['envelope_key']))
         assert envelope_key.has_private() is False
-
 
     def test_pubkey_only_encryption(self):
         curve = 'NIST P-384'
@@ -64,7 +60,6 @@ class TestEccTransform(TestCase):
         enc_data, materials = ecc_transform.encapsulate(data=data)
         assert enc_data
         assert enc_data != data
-
 
     def test_pubkey_only_decryption(self):
         curve = 'NIST P-384'

--- a/src/benji/tests/test_transform_ecc.py
+++ b/src/benji/tests/test_transform_ecc.py
@@ -1,0 +1,74 @@
+from unittest import TestCase
+
+from Crypto.PublicKey import ECC
+
+from benji.config import ConfigDict
+from benji.transform.ecc import Transform
+
+
+class TestEccTransform(TestCase):
+    
+    @staticmethod
+    def _get_transform_args(key):
+        conf = ConfigDict()
+        conf['EccKey'] = Transform._pack_envelope_key(key)
+        conf['EccCurve'] = key.curve
+        return Transform(name='EccTest', config=None, module_configuration=conf)
+
+
+    @classmethod
+    def _get_transform(cls):
+        curve = 'NIST P-384'
+        return cls._get_transform_args(ECC.generate(curve=curve))
+        
+    
+    def setUp(self):
+        self.ecc_transform = self._get_transform()
+
+
+    def test_decryption(self):
+        data = b'THIS IS A TEST'
+        enc_data, materials = self.ecc_transform.encapsulate(data=data)
+        assert enc_data
+        assert enc_data != data
+
+        dec_data = self.ecc_transform.decapsulate(data=enc_data, materials=materials)
+        assert dec_data == data
+
+
+    def test_encryption_random(self):
+        ecc_transform_ref = self._get_transform()
+
+        data = b'THIS IS A TEST'
+        
+        enc_data, materials = self.ecc_transform.encapsulate(data=data)
+        enc_data_ref, materials_ref = ecc_transform_ref.encapsulate(data=data)
+
+        assert enc_data != enc_data_ref
+        assert materials['ecc_envelope_key'] != materials_ref['ecc_envelope_key']
+
+
+    def test_envelope_key(self):
+        data = b'THIS IS A TEST'
+        
+        enc_data, materials = self.ecc_transform.encapsulate(data=data)
+
+        envelope_key = self.ecc_transform._unpack_envelope_key(materials['ecc_envelope_key'])
+        assert envelope_key.has_private() is False
+
+
+    def test_pubkey_only_encryption(self):
+        curve = 'NIST P-384'
+        ecc_transform = self._get_transform_args(ECC.generate(curve=curve).public_key())
+        data = b'THIS IS A TEST'
+        enc_data, materials = ecc_transform.encapsulate(data=data)
+        assert enc_data
+        assert enc_data != data
+
+
+    def test_pubkey_only_decryption(self):
+        curve = 'NIST P-384'
+        ecc_transform = self._get_transform_args(ECC.generate(curve=curve).public_key())
+        data = b'THIS IS A TEST'
+        enc_data, materials = ecc_transform.encapsulate(data=data)
+        self.assertRaises(ValueError, ecc_transform.decapsulate, data=enc_data, materials=materials)

--- a/src/benji/transform/ecc.py
+++ b/src/benji/transform/ecc.py
@@ -1,0 +1,92 @@
+import base64
+from typing import Dict, Tuple, Optional
+from hashlib import sha256
+
+from Crypto.PublicKey import ECC
+
+from benji.config import Config, ConfigDict
+from benji.transform.base import TransformBase
+from benji.transform.aes_256_gcm import Transform as TransformAES
+from benji.logging import logger
+
+
+AES_KEY_LEN = 32
+
+
+class Transform(TransformAES):
+
+    def __init__(self, *, config: Config, name: str, module_configuration: ConfigDict) -> None:
+        ecc_key_der: str = Config.get_from_dict(module_configuration, 'EccKey', types=str)
+        ecc_curve: Optionl[str] = Config.get_from_dict(module_configuration, 'EccCurve', 'NIST P-384', types=str)
+
+        ecc_key = self._unpack_envelope_key(ecc_key_der)
+
+        if ecc_key.curve != ecc_curve:
+            raise ValueError('Key EccKey does not match the EccCurve setting. Found: {}, Expected: {}'.format(ecc_key.curve, ecc_curve))
+
+        self._ecc_key = ecc_key
+        self._ecc_curve = ecc_key.curve
+
+        assert self._ecc_key.pointQ.x.size_in_bytes() >= AES_KEY_LEN
+
+        # note: we don't actually have a "master" aes key, because the key is derived from the ECC key
+        # and set before calling the parent's encapsulate/decapsulate method
+        aes_config = module_configuration.copy()
+        aes_config['masterKey'] = base64.b64encode(b'\x00' * AES_KEY_LEN).decode('ascii')
+        super().__init__(config=config, name=name, module_configuration=aes_config)
+
+
+    @staticmethod
+    def _pack_envelope_key(key: ECC.EccKey) -> str:
+        return base64.b64encode(key.export_key(format='DER', compress=True)).decode('ascii')
+
+
+    @staticmethod
+    def _unpack_envelope_key(key: str) -> ECC.EccKey:
+        return ECC.import_key(base64.b64decode(key))
+
+
+    @staticmethod
+    def _ecc_point_to_key(point: ECC.EccPoint) -> bytes:
+        sha = sha256(int.to_bytes(int(point.x), point.size_in_bytes(), 'big'))
+        sha.update(int.to_bytes(int(point.y), point.size_in_bytes(), 'big'))
+        return sha.digest()
+
+
+    def _create_ecc_enc_key(self) -> Tuple[bytes, ECC.EccKey]:
+        cipher_privkey = ECC.generate(curve=self._ecc_curve)
+        shared_key = self._ecc_point_to_key(self._ecc_key.pointQ * cipher_privkey.d)
+        return (shared_key, cipher_privkey.public_key())
+
+
+    def _create_ecc_dec_key(self, cipher_pubkey: ECC.EccKey) -> bytes:
+        return self._ecc_point_to_key(self._ecc_key.d * cipher_pubkey.pointQ)
+
+
+    def encapsulate(self, *, data: bytes) -> Tuple[Optional[bytes], Optional[Dict]]:
+        if self._ecc_key.has_private():
+            logger.warning('EccKey from config includes private key data, which is not needed for encryption!')
+        self._master_key, encrypted_key = self._create_ecc_enc_key()
+        assert len(self._master_key) == AES_KEY_LEN
+
+        enc_data, materials = super().encapsulate(data=data)
+        materials['ecc_envelope_key'] = self._pack_envelope_key(encrypted_key)
+
+        return enc_data, materials
+
+
+    def decapsulate(self, *, data: bytes, materials: Dict) -> bytes:
+        if not self._ecc_key.has_private():
+            raise ValueError('EccKey from config does not include private key data.')
+        if 'ecc_envelope_key' not in materials:
+            raise KeyError('Encryption materials are missing required key ecc_envelope_key.')
+
+        ecc_envelope_key = self._unpack_envelope_key(materials['ecc_envelope_key'])
+        self._master_key = self._create_ecc_dec_key(ecc_envelope_key)
+
+        if len(self._master_key) != AES_KEY_LEN:
+            raise ValueError('Decrypted encryption materials master key has wrong length of {}. '
+                             'It must be {} bytes long.'.format(len(self._master_key), AES_KEY_LEN))
+
+        return super().decapsulate(data=data, materials=materials)
+

--- a/src/benji/transform/ecc.py
+++ b/src/benji/transform/ecc.py
@@ -5,21 +5,17 @@ from hashlib import sha256
 from Crypto.PublicKey import ECC
 
 from benji.config import Config, ConfigDict
-from benji.transform.base import TransformBase
 from benji.transform.aes_256_gcm import Transform as TransformAES
 from benji.logging import logger
-
-
-AES_KEY_LEN = 32
 
 
 class Transform(TransformAES):
 
     def __init__(self, *, config: Config, name: str, module_configuration: ConfigDict) -> None:
         ecc_key_der: str = Config.get_from_dict(module_configuration, 'EccKey', types=str)
-        ecc_curve: Optionl[str] = Config.get_from_dict(module_configuration, 'EccCurve', 'NIST P-384', types=str)
+        ecc_curve: Optional[str] = Config.get_from_dict(module_configuration, 'EccCurve', 'NIST P-384', types=str)
 
-        ecc_key = self._unpack_envelope_key(ecc_key_der)
+        ecc_key = self._unpack_envelope_key(base64.b64decode(ecc_key_der))
 
         if ecc_key.curve != ecc_curve:
             raise ValueError('Key EccKey does not match the EccCurve setting. Found: {}, Expected: {}'.format(ecc_key.curve, ecc_curve))
@@ -27,24 +23,21 @@ class Transform(TransformAES):
         self._ecc_key = ecc_key
         self._ecc_curve = ecc_key.curve
 
-        assert self._ecc_key.pointQ.x.size_in_bytes() >= AES_KEY_LEN
+        assert self._ecc_key.pointQ.size_in_bytes() >= self.AES_KEY_LEN
 
         # note: we don't actually have a "master" aes key, because the key is derived from the ECC key
         # and set before calling the parent's encapsulate/decapsulate method
         aes_config = module_configuration.copy()
-        aes_config['masterKey'] = base64.b64encode(b'\x00' * AES_KEY_LEN).decode('ascii')
+        aes_config['masterKey'] = base64.b64encode(b'\x00' * self.AES_KEY_LEN).decode('ascii')
         super().__init__(config=config, name=name, module_configuration=aes_config)
 
+    @staticmethod
+    def _pack_envelope_key(key: ECC.EccKey) -> bytes:
+        return key.export_key(format='DER', compress=True)
 
     @staticmethod
-    def _pack_envelope_key(key: ECC.EccKey) -> str:
-        return base64.b64encode(key.export_key(format='DER', compress=True)).decode('ascii')
-
-
-    @staticmethod
-    def _unpack_envelope_key(key: str) -> ECC.EccKey:
-        return ECC.import_key(base64.b64decode(key))
-
+    def _unpack_envelope_key(key: bytes) -> ECC.EccKey:
+        return ECC.import_key(key)
 
     @staticmethod
     def _ecc_point_to_key(point: ECC.EccPoint) -> bytes:
@@ -52,41 +45,21 @@ class Transform(TransformAES):
         sha.update(int.to_bytes(int(point.y), point.size_in_bytes(), 'big'))
         return sha.digest()
 
-
-    def _create_ecc_enc_key(self) -> Tuple[bytes, ECC.EccKey]:
+    def _create_envelope_key(self) -> Tuple[bytes, bytes]:
         cipher_privkey = ECC.generate(curve=self._ecc_curve)
         shared_key = self._ecc_point_to_key(self._ecc_key.pointQ * cipher_privkey.d)
-        return (shared_key, cipher_privkey.public_key())
+        return shared_key, self._pack_envelope_key(cipher_privkey.public_key())
 
-
-    def _create_ecc_dec_key(self, cipher_pubkey: ECC.EccKey) -> bytes:
-        return self._ecc_point_to_key(self._ecc_key.d * cipher_pubkey.pointQ)
-
+    def _derive_envelope_key(self, cipher_pubkey: bytes) -> bytes:
+        ecc_point = self._unpack_envelope_key(cipher_pubkey)
+        return self._ecc_point_to_key(ecc_point.pointQ * self._ecc_key.d)
 
     def encapsulate(self, *, data: bytes) -> Tuple[Optional[bytes], Optional[Dict]]:
         if self._ecc_key.has_private():
             logger.warning('EccKey from config includes private key data, which is not needed for encryption!')
-        self._master_key, encrypted_key = self._create_ecc_enc_key()
-        assert len(self._master_key) == AES_KEY_LEN
-
-        enc_data, materials = super().encapsulate(data=data)
-        materials['ecc_envelope_key'] = self._pack_envelope_key(encrypted_key)
-
-        return enc_data, materials
-
+        return super().encapsulate(data=data)
 
     def decapsulate(self, *, data: bytes, materials: Dict) -> bytes:
         if not self._ecc_key.has_private():
             raise ValueError('EccKey from config does not include private key data.')
-        if 'ecc_envelope_key' not in materials:
-            raise KeyError('Encryption materials are missing required key ecc_envelope_key.')
-
-        ecc_envelope_key = self._unpack_envelope_key(materials['ecc_envelope_key'])
-        self._master_key = self._create_ecc_dec_key(ecc_envelope_key)
-
-        if len(self._master_key) != AES_KEY_LEN:
-            raise ValueError('Decrypted encryption materials master key has wrong length of {}. '
-                             'It must be {} bytes long.'.format(len(self._master_key), AES_KEY_LEN))
-
         return super().decapsulate(data=data, materials=materials)
-


### PR DESCRIPTION
This PR adds a transform module allowing asymmetric encryption using elliptic curve cryptography (ECC). The module derives intermediate encryption keys for each block and then uses the available `aes_256_gcm` module for actual encryption of data.

Motivation: In case an attacker gains access to the environment used to configure and use benji they will likely have access to encrypted backups and the encryption key. Backups may include sensitive information that has been deleted from the active environment but is kept for legal compliance or other reasons. To mitigate the impact of a successful attack, backups can be encrypted with this ECC module, preventing the attacker from decrypting backups.

Implementation detail: The available `aes_256_gcm` module is used without any modification. This leads to some minor overhead, especially wrt to the creation of the per-block "envelope" keys. I can do a slight refactoring there but would like to get a concept ack before that.

Important note: Unfortunately PyCryptodome does not include any easy-to-use high-level interfaces for ECC. The implementation is based on the information found here: https://cryptobook.nakov.com/asymmetric-key-ciphers/ecc-encryption-decryption
I am not a cryptographer and cannot guarantee that this module implements ECC in a secure way. I'd highly appreciate if someone with more knowledge in the area could sanity-check this implementation.