### PR TITLE
Add S3 retry timeout and max attempts config options

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -728,6 +728,19 @@ during some operations. Enabling this setting prevents this by not sending
 this HTTP header. This needs to be set to ``true`` when connecting
 to a Google Storage bucket.
 
+* name: **read_timeout**
+* type: integer
+* default: 30
+
+Seconds until a s3 read request times out
+
+* name: **retries**
+* type: integer
+* default: 4
+
+Number of retries for s3 requests (boto3 retries.max_attempts) until it finally fails
+
+
 Storage Module b2
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -728,18 +728,25 @@ during some operations. Enabling this setting prevents this by not sending
 this HTTP header. This needs to be set to ``true`` when connecting
 to a Google Storage bucket.
 
-* name: **read_timeout**
+* name: **connectTimeout**
+* type: float
+* default: 60.0
+
+This sets the connect timeout for S3 requests.
+
+* name: **readTimeout**
+* type: float
+* default: 60.0
+
+This sets the read timeout for S3 requests.
+
+* name: **maxAttempts**
 * type: integer
-* default: 30
+* default: 5
 
-Seconds until a s3 read request times out
-
-* name: **retries**
-* type: integer
-* default: 4
-
-Number of retries for s3 requests (boto3 retries.max_attempts) until it finally fails
-
+This sets the maximum number of attempts to complete an S3 request. It includes the
+initial request and so cannot be set lower than one. Benji uses the ``standard`` retry
+mode of the ``boto3`` library.
 
 Storage Module b2
 ~~~~~~~~~~~~~~~~~~

--- a/etc/benji.yaml
+++ b/etc/benji.yaml
@@ -43,6 +43,9 @@ storages:
 #      bucketName:
 #      addressingStyle:
 #      disableEncodingType: false
+#      connectTimeout:
+#      readTimeout:
+#      maxAttempts:
 #
 # For Google S3 API use:
 #

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ Topic :: System :: Archiving :: Backup
         'diskcache>=3.0.6',
     ],
     extras_require={
-        's3': ['boto3>=1.7.28'],
+        's3': ['boto3>=1.15.0'],
         'b2': ['b2>=1.3.2,<=1.3.8'],
         'compression': ['zstandard>=0.9.0'],
         # For RBD support the packages supplied by the Linux distribution or the Ceph team should be used,

--- a/src/benji/schemas/v1/benji.storage.s3.yaml
+++ b/src/benji/schemas/v1/benji.storage.s3.yaml
@@ -51,9 +51,18 @@ configuration:
       type: boolean
       empty: False
       default: False
-    retries:
+    connectTimeout:
+      type: float
+      empty: False
+      min: 0.0
+      default: 60.0
+    readTimeout:
+      type: float
+      empty: False
+      min: 0.0
+      default: 60.0
+    maxAttempts:
       type: integer
       empty: False
-    read_timeout:
-      type: integer
-      empty: False
+      min: 1
+      default: 5

--- a/src/benji/schemas/v1/benji.storage.s3.yaml
+++ b/src/benji/schemas/v1/benji.storage.s3.yaml
@@ -51,3 +51,9 @@ configuration:
       type: boolean
       empty: False
       default: False
+    retries:
+      type: integer
+      empty: False
+    read_timeout:
+      type: integer
+      empty: False

--- a/src/benji/storage/s3.py
+++ b/src/benji/storage/s3.py
@@ -34,6 +34,8 @@ class Storage(ReadCacheStorageBase):
         use_ssl = Config.get_from_dict(module_configuration, 'useSsl', None, types=bool)
         addressing_style = Config.get_from_dict(module_configuration, 'addressingStyle', None, types=str)
         signature_version = Config.get_from_dict(module_configuration, 'signatureVersion', None, types=str)
+        read_timeout = Config.get_from_dict(module_configuration, 'read_timeout', None, types=int)
+        retries = Config.get_from_dict(module_configuration, 'retries', None, types=int)
 
         self._bucket_name = Config.get_from_dict(module_configuration, 'bucketName', types=str)
         self._disable_encoding_type = Config.get_from_dict(module_configuration, 'disableEncodingType', types=bool)
@@ -58,6 +60,12 @@ class Storage(ReadCacheStorageBase):
 
         if signature_version:
             resource_config['signature_version'] = signature_version
+
+        if read_timeout:
+            resource_config['read_timeout'] = read_timeout
+
+        if retries:
+            resource_config['retries'] = { 'max_attempts':  retries }
 
         self._resource_config['config'] = BotoCoreClientConfig(**resource_config)
         self._local = threading.local()

--- a/src/benji/tests/storage/test_s3.py
+++ b/src/benji/tests/storage/test_s3.py
@@ -26,8 +26,9 @@ class test_s3(StorageTestCase, TestCase):
             consistencyCheckWrites: True
             simultaneousWrites: 5
             simultaneousReads: 5
-            retries: 1000
-            read_timeout: 300
+            connectTimeout: 10.0
+            readTimeout: 10.0
+            maxAttempts: 1
             activeTransforms:
               - zstd
               - k1

--- a/src/benji/tests/storage/test_s3.py
+++ b/src/benji/tests/storage/test_s3.py
@@ -26,6 +26,8 @@ class test_s3(StorageTestCase, TestCase):
             consistencyCheckWrites: True
             simultaneousWrites: 5
             simultaneousReads: 5
+            retries: 1000
+            read_timeout: 300
             activeTransforms:
               - zstd
               - k1

--- a/tests/minio-setup/docker-compose.yaml
+++ b/tests/minio-setup/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
  minio1:
-  image: minio/minio:RELEASE.2018-10-25T01-27-03Z
+  image: minio/minio:RELEASE.2021-01-16T02-19-44Z
   ports:
    - "9901:9000"
   environment:


### PR DESCRIPTION
This is an improved version of #102 and adds new options to change the S3 request timeouts and the maximum number of retries. It will behave differently than before because we're also switching from using the legacy retry mode to standard mode as recommended by the documentation.