### PR TITLE
Set a `grouping_key` when exporting prometheus metrics

### DIFF
--- a/images/benji-k8s/k8s-tools/src/benji/k8s_tools/scripts/backup_pvc.py
+++ b/images/benji-k8s/k8s-tools/src/benji/k8s_tools/scripts/backup_pvc.py
@@ -211,7 +211,11 @@ def ceph_backup_post_success(sender: str, volume: str, pool: str, image: str, ve
     prometheus.backup_completion_time.labels(volume=volume).set(completion_time)
     prometheus.backup_runtime_seconds.labels(volume=volume).set(completion_time - start_time)
     prometheus.backup_status_succeeded.labels(volume=volume).set(1)
-
+    prometheus.push(prometheus.backup_registry,
+                    grouping_key={
+                        'pvc_namespace': pvc_namespace,
+                        'pvc_name': pvc_name
+                    })
     try:
         benji.k8s_tools.kubernetes.create_pvc_event(
             type='Normal',
@@ -239,6 +243,11 @@ def ceph_backup_post_error(sender: str, volume: str, pool: str, image: str, vers
     prometheus.backup_completion_time.labels(volume=volume).set(completion_time)
     prometheus.backup_runtime_seconds.labels(volume=volume).set(completion_time - start_time)
     prometheus.backup_status_failed.labels(volume=volume).set(1)
+    prometheus.push(prometheus.backup_registry,
+                    grouping_key={
+                        'pvc_namespace': pvc_namespace,
+                        'pvc_name': pvc_name
+                    })
 
     benji.k8s_tools.kubernetes.create_pvc_event(type='Warning',
                                                 reason='FailedBackup',
@@ -334,5 +343,4 @@ def main():
                     version_labels=version_labels,
                     context=context)
 
-    prometheus.push(prometheus.backup_registry)
     sys.exit(0)

--- a/images/benji-k8s/k8s-tools/src/benji/k8s_tools/scripts/command.py
+++ b/images/benji-k8s/k8s-tools/src/benji/k8s_tools/scripts/command.py
@@ -22,12 +22,12 @@ def main():
         completion_time = time.time()
         prometheus.command_completion_time.labels(command=command).set(completion_time)
         prometheus.command_runtime_seconds.labels(command=command).set(completion_time - start_time)
-        prometheus.push(prometheus.command_registry)
+        prometheus.push(prometheus.command_registry, grouping_key={"command": command})
         raise exception
     else:
         prometheus.command_status_succeeded.labels(command=command).set(1)
         completion_time = time.time()
         prometheus.command_completion_time.labels(command=command).set(completion_time)
         prometheus.command_runtime_seconds.labels(command=command).set(completion_time - start_time)
-        prometheus.push(prometheus.command_registry)
+        prometheus.push(prometheus.command_registry, grouping_key={"command": command})
         sys.exit(0)

--- a/images/benji-k8s/k8s-tools/src/benji/k8s_tools/scripts/versions_status.py
+++ b/images/benji-k8s/k8s-tools/src/benji/k8s_tools/scripts/versions_status.py
@@ -31,5 +31,5 @@ def main():
 
     prometheus.older_incomplete_versions.set(len(incomplete_versions['versions']))
     prometheus.invalid_versions.set(len(invalid_versions['versions']))
-    prometheus.push(prometheus.version_status_registry)
+    prometheus.push(prometheus.version_status_registry, grouping_key={})
     sys.exit(0)

--- a/src/benji/helpers/prometheus.py
+++ b/src/benji/helpers/prometheus.py
@@ -2,6 +2,7 @@ import logging
 import urllib.error
 
 from prometheus_client import CollectorRegistry, Gauge, pushadd_to_gateway, generate_latest
+from typing import Dict
 
 from benji.helpers.settings import prom_push_gateway, benji_instance
 
@@ -11,12 +12,13 @@ backup_registry = CollectorRegistry()
 version_status_registry = CollectorRegistry()
 
 
-def push(registry: CollectorRegistry):
+def push(registry: CollectorRegistry, grouping_key: Dict[str, str] = {}):
     if prom_push_gateway is not None and benji_instance is not None:
         logger.info(f'Pushing Prometheus metrics to gateway {prom_push_gateway}.')
         logger.debug(generate_latest(registry).decode('utf-8'))
+
         try:
-            pushadd_to_gateway(prom_push_gateway, job=benji_instance, registry=registry)
+            pushadd_to_gateway(prom_push_gateway, job=benji_instance, registry=registry, grouping_key=grouping_key)
         except urllib.error.URLError as exception:
             logger.error(f'Pushing Prometheus metrics failed with a {type(exception).__name__} exception: {str(exception)}')
             logger.error('Ignoring.')

--- a/src/benji/helpers/prometheus.py
+++ b/src/benji/helpers/prometheus.py
@@ -12,7 +12,7 @@ backup_registry = CollectorRegistry()
 version_status_registry = CollectorRegistry()
 
 
-def push(registry: CollectorRegistry, grouping_key: Dict[str, str] = {}):
+def push(registry: CollectorRegistry, grouping_key: Dict[str, str]):
     if prom_push_gateway is not None and benji_instance is not None:
         logger.info(f'Pushing Prometheus metrics to gateway {prom_push_gateway}.')
         logger.debug(generate_latest(registry).decode('utf-8'))


### PR DESCRIPTION
Set a grouping_key when exporting prometheus metrics to ensure that metrics
for different runs are not overwritten.

Fix a bug in `backup_pvc` where metrics are not exported on ceph failure.
Instead, just push to the gatewhere right where the metrics are incremented.

Note: There is still an additional issue not handled here as a ceph failure
will raise an exception and skip backing up any additional PVCs in the
namespace, so it won't export any metrics for those.

Issue #124 