### PR TITLE
More robust parsing of csi volume handle

### DIFF
--- a/images/benji-k8s/k8s-tools/src/benji/k8s_tools/kubernetes.py
+++ b/images/benji-k8s/k8s-tools/src/benji/k8s_tools/kubernetes.py
@@ -229,6 +229,7 @@ def determine_rbd_image_from_pv(
         #      1111 Number of chars in the cluster id
         #           2222 cluster id
         #                3333333333333333 padded id of the pool
+        # imageSuffix must be chosen so the total length of the volume handle is 36 chars (wtf?)
         # The ceph-csi parser says nothing about the format for imageName or the imageSuffix, so it's more
         # correct to parse the volume handle from the start, rather than the end.
                                                                                                                                                           


### PR DESCRIPTION
Hi, I have a cluster where I create ceph-csi PVs and I noticed that the volume names expected by the determine_rbd_image_from_pv doesn't like my volume names because it assumes the last part of the volume handle has a specific number of dashes, even though the only requirement from ceph-csi is that it must have the first 4 parts according to a very rigid sceme and an overall length of 36 chars.