### PR TITLE
Add S3 Storage Class option

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -686,6 +686,12 @@ Sets the bucket name.
 
 Sets the region of the bucket.
 
+* name: **storageClass**
+* type: string
+* default: STANDARD
+
+Sets the Storage Class.
+
 * name: **useSsl**
 * type: bool
 * default: from ``boto3`` library, ignored if **endpointUrl** is specified

--- a/src/benji/schemas/v1/benji.storage.s3.yaml
+++ b/src/benji/schemas/v1/benji.storage.s3.yaml
@@ -47,6 +47,10 @@ configuration:
       type: string
       empty: False
       required: True
+    storageClass:
+      type: string
+      empty: False
+      default: STANDARD
     disableEncodingType:
       type: boolean
       empty: False

--- a/src/benji/storage/s3.py
+++ b/src/benji/storage/s3.py
@@ -39,6 +39,7 @@ class Storage(ReadCacheStorageBase):
         max_attempts = Config.get_from_dict(module_configuration, 'maxAttempts', types=int)
 
         self._bucket_name = Config.get_from_dict(module_configuration, 'bucketName', types=str)
+        self._storage_class = Config.get_from_dict(module_configuration, 'storageClass', types=str)
         self._disable_encoding_type = Config.get_from_dict(module_configuration, 'disableEncodingType', types=bool)
 
         self._resource_config = {
@@ -90,7 +91,7 @@ class Storage(ReadCacheStorageBase):
     def _write_object(self, key: str, data: bytes) -> None:
         self._init_connection()
         object = self._local.bucket.Object(key)
-        object.put(Body=data)
+        object.put(Body=data, StorageClass=self._storage_class)
 
     def _read_object(self, key: str) -> bytes:
         self._init_connection()


### PR DESCRIPTION
This add a storageClass option for S3 storage.
https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html
By default, it keeps STANDARD class.