### PR TITLE
Add workflow for releasing chart

### DIFF
--- a/.github/workflows/release_chart.yaml
+++ b/.github/workflows/release_chart.yaml
@@ -1,0 +1,32 @@
+---
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release_chart:
+    name: "Release Chart"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.10.0
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.1
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This commit adds a GitHub Actions workflow for releasing the Helm chart to GitHub Pages, which already exists on the upstream repository. Every time a version is incremented in `charts/*/Chart.yaml`, the action detects the change, packages the latest chart, and creates a new commit on the `gh-pages` branch which includes an updated `index.yml` (for Helm to read), and the new package.

For a working example of how that behaves, please see [my master branch](https://github.com/alexander-bauer/benji) and the [corresponding GitHub Pages page](https://alexander-bauer.github.io/benji/). The documentation pages are unaffected, but Helm is able to treat it as a repository.

![image](https://user-images.githubusercontent.com/1558334/193494171-b45648d2-8ee7-4293-95e8-0b0ee138e20d.png)
