### PR TITLE
Feature: added new flag '-d' to discard changes in writeable mode to prevent fixating version at nbd disconnect

### DIFF
--- a/docs/source/restore.rst
+++ b/docs/source/restore.rst
@@ -184,7 +184,7 @@ After connecting the NBD device you can initiate any repair procedures required 
 device will initiate a copy-on-write (COW) of the original blocks to a new *version* which is dynamically created
 by Benji.
 
-After disconnecting the NBD device Benji will start to fixate the COW *version*. Depending on how many changes
+Without the ``-d`` option, after disconnecting the NBD device Benji will start to fixate the COW *version*. Depending on how many changes
 have been done to the original *version* this will take some time!::
 
     INFO: [127.0.0.1:46526] disconnecting
@@ -216,6 +216,9 @@ the *version* the protection needs to be lifted with ``benji unprotect``.
 
 .. NOTE:: The new created COW *version* can be restored just like any other *version*. Both the original and the
     COW *version* are independent from each other and each can be removed without affecting the other.
+
+When the ``-d`` option is specified, the changes will not be fixated and will be discarded. No new version will be created.
+This is useful for booting from a nbd disk without creating a new Version from the changes, like in backup restore tests.
 
 Restoring Invalid *Versions*
 ----------------------------

--- a/src/benji/benji.py
+++ b/src/benji/benji.py
@@ -1479,3 +1479,9 @@ class BenjiStore(ReprMixIn):
         Locking.unlock_version(cow_version.uid)
         del self._cow[cow_version.uid]
         logger.info('Finished.')
+
+    def cow_discard_changes(self, cow_version: Version) -> None:
+        Locking.unlock_version(cow_version.uid)
+        cow_version.remove()
+        del self._cow[cow_version.uid]
+        logger.info('Finished.')

--- a/src/benji/commands.py
+++ b/src/benji/commands.py
@@ -344,11 +344,11 @@ class Commands:
                                      sys.stdout,
                                      ignore_relationships=(((Version,), ('blocks',)),))
 
-    def nbd(self, bind_address: str, bind_port: str, read_only: bool) -> None:
+    def nbd(self, bind_address: str, bind_port: str, read_only: bool, discard_changes: bool) -> None:
         with Benji(self.config) as benji_obj:
             store = BenjiStore(benji_obj)
             addr = (bind_address, bind_port)
-            server = NbdServer(addr, store, read_only)
+            server = NbdServer(addr, store, read_only, discard_changes)
             logger.info("Starting to serve NBD on %s:%s" % (addr[0], addr[1]))
             server.serve_forever()
 

--- a/src/benji/nbdserver.py
+++ b/src/benji/nbdserver.py
@@ -152,12 +152,13 @@ class NbdServer(ReprMixIn):
     EOVERFLOW = 75  # Value too large.
     ESHUTDOWN = 108  # Server is in the process of being shut down.
 
-    def __init__(self, address: Tuple[str, str], store: BenjiStore, read_only: bool = True) -> None:
+    def __init__(self, address: Tuple[str, str], store: BenjiStore, read_only: bool = True, discard_changes: bool = False) -> None:
         self.log = logging.getLogger(__package__)
 
         self.address = address
         self.store = store
         self.read_only = read_only
+        self.discard_changes = discard_changes
 
         if asyncio.get_event_loop().is_closed():
             asyncio.set_event_loop(asyncio.new_event_loop())
@@ -380,6 +381,9 @@ class NbdServer(ReprMixIn):
 
         finally:
             if cow_version:
+              if self.discard_changes:
+                self.store.cow_discard_changes(cow_version)
+              else:
                 self.store.fixate(cow_version)
             if version:
                 self.store.close(version)

--- a/src/benji/scripts/benji.py
+++ b/src/benji/scripts/benji.py
@@ -218,6 +218,7 @@ def main():
     p.add_argument('-a', '--bind-address', default='127.0.0.1', help='Bind to the specified IP address')
     p.add_argument('-p', '--bind-port', default=10809, help='Bind to the specified port')
     p.add_argument('-r', '--read-only', action='store_true', default=False, help='NBD device is read-only')
+    p.add_argument('-d', '--discard-changes', action='store_true', default=False, help='Discard changes to NDBD device after disconnecting. Don\'t create new version.')
     p.set_defaults(func='nbd')
 
     # PROTECT

--- a/src/benji/tests/test_nbd.py
+++ b/src/benji/tests/test_nbd.py
@@ -68,7 +68,8 @@ class NbdTestCase:
         store = BenjiStore(benji_obj)
         addr = ('127.0.0.1', self.SERVER_PORT)
         read_only = False
-        self.nbd_server = NbdServer(addr, store, read_only)
+        discard_changes = False
+        self.nbd_server = NbdServer(addr, store, read_only, discard_changes)
         logger.info("Starting to serve NBD on %s:%s" % (addr[0], addr[1]))
 
         self.subprocess_run(args=['sudo', 'modprobe', 'nbd'])


### PR DESCRIPTION
This is useful for booting a qemu kvm directly on a existing backup version for testing purposes, without writing all changes like paging file to remote s3 storage.