### PR TITLE
fix(restapi): fix API ignoring query string parameters for GET requests

### DIFF
--- a/src/benji/restapi.py
+++ b/src/benji/restapi.py
@@ -43,7 +43,9 @@ def route(path: str, **decorator_kwargs):
         request_args = {
             name: value for name, value in annotations.items() if isinstance(value, fields.Field) and name != "return"
         }
-        func.bottle_route['apply'] = use_kwargs(request_args)
+
+        location = 'query' if decorator_kwargs['method'] == 'GET' else 'json'
+        func.bottle_route['apply'] = use_kwargs(request_args, location=location)
 
         @functools.wraps(func)
         def wrapped_func(*args, **kwargs):


### PR DESCRIPTION
Hello, it's me again 🙂 

Webargs 6.0 [changed](https://webargs.readthedocs.io/en/latest/upgrading.html#upgrading-to-6-0) the behaviour of data location lookups to be single-source instead of a union of all locations, the default now is `json` and it only looks in there.

This broke the `/versions` endpoint of the rest-api, because it expects `filter_expression` and `include_blocks` as query string parameters: `GET` method does not have a request body (`json`) in its specification, so only query string is available.

Inside the route-decorated function call, the following state can be observed:

```python
request.body.getvalue(): filter_expression=123&include_blocks=true
locals(): {'self': <benji.restapi.RestAPI object at 0x7f5a23fc6280>, 'filter_expression': None, 'include_blocks': False}
```

This change fixes this problem by forcing webargs to look into the query string parameters if it is a `GET` request, falling back to the default `json` otherwise. 