### PR TITLE
Update k8s python client lib to address CVE-2020-1747

### DIFF
--- a/images/benji-k8s/k8s-tools/setup.py
+++ b/images/benji-k8s/k8s-tools/setup.py
@@ -12,7 +12,7 @@ setup(name='benji-k8s-tools',
       package_dir={
           '': 'src',
       },
-      install_requires=['benji', 'kubernetes>=10.0.0,<11'],
+      install_requires=['benji', 'kubernetes>=19.15.0'],
       entry_points="""
         [console_scripts]
             benji-backup-pvc = benji.k8s_tools.scripts.backup_pvc:main

--- a/images/benji-k8s/k8s-tools/src/benji/k8s_tools/kubernetes.py
+++ b/images/benji-k8s/k8s-tools/src/benji/k8s_tools/kubernetes.py
@@ -144,7 +144,7 @@ def pod_exec(args: List[str],
 
 
 def create_pvc_event(*, type: str, reason: str, message: str, pvc_namespace: str, pvc_name: str,
-                     pvc_uid: str) -> kubernetes.client.models.v1_event.V1Event:
+                     pvc_uid: str) -> kubernetes.client.models.core_v1_event.CoreV1Event:
     event_name = '{}-{}'.format(benji_instance, str(uuid.uuid4()))
     # Kubernetes requires a time including microseconds
     event_time = datetime.datetime.utcnow().isoformat(timespec='microseconds') + 'Z'


### PR DESCRIPTION
Hello!

The `kubernetes>=10.0.0,<11` python client library currently used in the project relies on PyYAML 3.13 lib which has [CVE-2020-1747 ](https://github.com/advisories/GHSA-6757-jp84-gxfx)

This issue has been addressed in [18.20.0](https://github.com/kubernetes-client/python/commit/5ef35631c69e71bc34de0f687b1933815526c724) release.

But the following 19.15.0 release introduced some changes in the names of some modules and classes.

This PR bumps the kubernetes python client library and makes the relevant code changes.